### PR TITLE
Fix baseline grid step and export button

### DIFF
--- a/content.js
+++ b/content.js
@@ -147,7 +147,7 @@ function drawBaselineGrid() {
     if (!settings.showBaselineGrid || !settings.isProUser) return;
     ctx.strokeStyle = 'rgba(255,0,0,0.2)';
     ctx.lineWidth = 1;
-    const step = 4; // 4px baseline
+    const step = Number(settings.showBaselineGrid) || 4;
     for (let y = 0; y < ui.baselineCanvas.height; y += step) {
         ctx.beginPath();
         ctx.moveTo(0, y);
@@ -468,6 +468,9 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
         }
     } else if (request.action === 'getInspectorState') {
         sendResponse({ isActive: window.inspector && window.inspector.isActive });
+    } else if (request.action === 'exportImage') {
+        exportOverlayAsImage();
+        sendResponse({ ok: true });
     } else if (request.action === 'fallbackCopyToClipboard') {
         // Try Clipboard API first
         if (navigator.clipboard && navigator.clipboard.writeText) {


### PR DESCRIPTION
## Summary
- use stored baseline grid spacing in content script
- handle `exportImage` message so popup export works

## Testing
- `npm run lint` *(fails: ESLint couldn't find the config "prettier")*

------
https://chatgpt.com/codex/tasks/task_e_686d6b83a9f8832bb5cd0989bd303af3