### PR TITLE
Add screenshot capture feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 - Planned: Integration with Gumroad API for dynamic license validation
 - Planned: More Pro features (custom color overlays, measurement history)
+- Added screenshot capture functionality in the popup
 
 ## [2.0.0] - 2025-06-27
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ SnapMeasure Pro is a Chrome extension for measuring and inspecting UI elements, 
 ### Pro Features
 - **Baseline Grid**: Show a baseline grid for typography alignment.
 - **Guides**: Add persistent vertical/horizontal guides (double-click overlay to add, drag to move, double-click guide to remove).
-- **Screenshot Overlay**: Upload a screenshot for pixel-perfect comparison.
+- **Screenshot Overlay**: Upload a screenshot or capture the current view for pixel-perfect comparison.
+- **Screenshot Capture**: Grab a screenshot of the active tab directly from the popup.
 - **Spec Export**: Export overlay as an image for documentation.
 
 ## How It Works

--- a/background.js
+++ b/background.js
@@ -88,4 +88,21 @@ chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
             );
         });
         return true;
+    } else if (request.action === 'captureScreenshot') {
+        chrome.tabs.captureVisibleTab(null, { format: 'png' }, (dataUrl) => {
+            if (chrome.runtime.lastError || !dataUrl) {
+                sendResponse({ ok: false, error: chrome.runtime.lastError?.message || 'Capture failed' });
+                return;
+            }
+            fetch(dataUrl)
+                .then(res => res.blob())
+                .then(blob => createImageBitmap(blob))
+                .then(bitmap => {
+                    chrome.storage.local.set({
+                        screenshotData: dataUrl,
+                        screenshotImageSize: { width: bitmap.width, height: bitmap.height }
+                    }).then(() => sendResponse({ ok: true }));
+                });
+        });
+        return true;
     }});

--- a/popup.html
+++ b/popup.html
@@ -100,6 +100,7 @@
         <span><svg class="icon" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="9" y="9" width="6" height="6" rx="1"/></svg>Overlay Image</span>
         <button id="screenshot-upload-btn" class="action-btn">Pick…</button>
         <input id="screenshot-upload" type="file" accept="image/*" style="display:none">
+        <button id="screenshot-capture-btn" class="action-btn">Capture</button>
         <button id="screenshot-delete-btn" class="action-btn delete-btn">Delete</button>
         <input id="screenshot-opacity" type="range" min="0" max="1" step="0.05">
         <button id="export-button" class="action-btn">Export</button>

--- a/popup.js
+++ b/popup.js
@@ -14,6 +14,7 @@ document.addEventListener('DOMContentLoaded', () => {
         guidesToggle: $('guides-toggle'),
         screenshotUploadBtn: $('screenshot-upload-btn'),
         screenshotUpload: $('screenshot-upload'),
+        screenshotCaptureBtn: $('screenshot-capture-btn'),
         screenshotDeleteBtn: $('screenshot-delete-btn'),
         screenshotOpacity: $('screenshot-opacity'),
         exportButton: $('export-button'),
@@ -32,8 +33,9 @@ document.addEventListener('DOMContentLoaded', () => {
     // group for bulk enabling/disabling
     const proControls = [
         els.gridToggle, els.baselineSelect, els.guidesToggle,
-        els.screenshotUploadBtn, els.screenshotDeleteBtn,
-        els.screenshotOpacity, els.exportButton
+        els.screenshotUploadBtn, els.screenshotCaptureBtn,
+        els.screenshotDeleteBtn, els.screenshotOpacity,
+        els.exportButton
     ];
 
     // Add inspector status indicator
@@ -170,6 +172,8 @@ document.addEventListener('DOMContentLoaded', () => {
             chrome.storage.local.set({ screenshotData: ev.target.result });
         reader.readAsDataURL(file);
     });
+    els.screenshotCaptureBtn?.addEventListener('click', () =>
+        chrome.runtime.sendMessage({ action: 'captureScreenshot' }));
     els.screenshotDeleteBtn?.addEventListener('click', () =>
         chrome.storage.local.set({ screenshotData: null }));
     els.screenshotOpacity?.addEventListener('input', () =>


### PR DESCRIPTION
## Summary
- add screenshot capture button in the popup
- implement new `captureScreenshot` action in background service worker
- wire popup code to trigger capture and store result
- document screenshot capture in README and CHANGELOG

## Testing
- `npm run lint` *(fails: couldn't find ESLint config "prettier")*

------
https://chatgpt.com/codex/tasks/task_e_686d6ef25038832bb02377946e9ae89a